### PR TITLE
Hide discovered POIs while active

### DIFF
--- a/WorldFlightMap.lua
+++ b/WorldFlightMap.lua
@@ -268,6 +268,15 @@ function WorldFlightMapProvider:AddFlightNode(taxiNodeData)
 				--pin:SetIgnoreGlobalPinScale(true)
 				
 				pin:SetShown(taxiNodeData.state ~= Enum.FlightPathState.Unreachable); -- Only show if part of a route, handled in the route building functions
+
+				for poiPin in self:GetMap():EnumeratePinsByTemplate("FlightPointPinTemplate") do
+					if poiPin.name == taxiNodeData.name and playAnim then
+						poiPin:Hide()
+					else
+						poiPin:ClearNudgeSettings()
+						poiPin:ApplyCurrentPosition()
+					end
+				end
 			end
 		end
 	end


### PR DESCRIPTION
The FlightPointPin(s) show all flight points as POIs, even ones undiscovered, and when WFM shows its pins they get nudged out of position.
This patch will hide the POIs that are known, and un-nudge the ones that are not.

Before:
![image](https://user-images.githubusercontent.com/26496/107530264-fd708c00-6bbb-11eb-894c-c994b52bd382.png)

After:
![image](https://user-images.githubusercontent.com/26496/107530281-019ca980-6bbc-11eb-8eee-d079f1e87d4a.png)
